### PR TITLE
IIP-430 Exclude Hybris OOTB testsrc folders from import

### DIFF
--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -42,6 +42,7 @@ hybris.project.import.error.nothing.found.to.import=Nothing found to import
 hybris.project.import.error.unable.to.proceed=Unable to Proceed
 hybris.project.import.followSymlink=Include symbolic links for a project import
 hybris.project.import.scannExternalModules=Scan for hybris modules even in external modules i.e. eclipse. (slower import/refresh)
+hybris.project.import.excludeTestSources=Exclude test sources for OOTB modules
 hybris.project.view.junk.directory.name=junk (virtual directory)
 
 hybris.import.label.select.hybris.src.file=Select Source Code Zip File or Directory (Optional).
@@ -128,6 +129,7 @@ hybris.import.wizard.information.jrebel.label=JRebel && hotSwap
 hybris.import.wizard.information.jrebel.text=IDEA needs to build its own compile tree to enable hotSwap.<br/>Once the project is imported and indexed you need to trigger Build->Rebuild project once only.
 hybris.import.wizard.information.jira.label=Feedback
 hybris.import.wizard.information.jira.text=We'd love to hear from you! you can report any suggestion, feature request or a bug to us <a href="https://hybris-integration.atlassian.net/admin/users/sign-up">here</a>. 
+hybris.import.wizard.exclude.test.sources.label=Exclude test sources for OOTB modules
 hybris.business.process.provider.name=hybris Business Process
 hybris.business.process.timeout=Timeout:
 hybris.stats.permission.label=Statistics Collection

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.project.configurators.impl;
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants;
 import com.intellij.idea.plugin.hybris.project.configurators.ContentRootConfigurator;
+import com.intellij.idea.plugin.hybris.project.descriptors.CustomHybrisModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -143,7 +144,11 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             dirsToIgnore
         );
 
-        addTestSourceRoots(contentEntry, moduleDescriptor.getRootDirectory(), dirsToIgnore);
+        if(moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
+            addTestSourceRoots(contentEntry, moduleDescriptor.getRootDirectory(), dirsToIgnore);
+        } else {
+            excludeTestSourceRoots(contentEntry, moduleDescriptor.getRootDirectory());
+        }
 
         final File resourcesDirectory = new File(moduleDescriptor.getRootDirectory(), RESOURCES_DIRECTORY);
 
@@ -274,7 +279,11 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             JavaSourceRootType.SOURCE
         );
 
-        addTestSourceRoots(contentEntry, backOfficeModuleDirectory, dirsToIgnore);
+        if(moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
+            addTestSourceRoots(contentEntry, backOfficeModuleDirectory, dirsToIgnore);
+        } else {
+            excludeTestSourceRoots(contentEntry, backOfficeModuleDirectory);
+        }
 
         final File hmcResourcesDirectory = new File(backOfficeModuleDirectory, RESOURCES_DIRECTORY);
         contentEntry.addSourceFolder(
@@ -337,7 +346,11 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             JpsJavaExtensionService.getInstance().createSourceRootProperties("", true)
         );
 
-        addTestSourceRoots(contentEntry, webModuleDirectory, dirsToIgnore);
+        if(moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
+            addTestSourceRoots(contentEntry, webModuleDirectory, dirsToIgnore);
+        } else {
+            excludeTestSourceRoots(contentEntry, webModuleDirectory);
+        }
 
         excludeSubDirectories(contentEntry, webModuleDirectory, Arrays.asList(
             ADDON_SRC_DIRECTORY, TEST_CLASSES_DIRECTORY, COMMON_WEB_SRC_DIRECTORY
@@ -358,6 +371,15 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
                 JavaSourceRootType.TEST_SOURCE,
                 dirsToIgnore
             );
+        }
+    }
+
+    private static void excludeTestSourceRoots(
+        @NotNull final ContentEntry contentEntry,
+        @NotNull final File dir) {
+
+        for (String testSrcDirName : TEST_SRC_DIR_NAMES) {
+            excludeDirectory(contentEntry, new File(dir, testSrcDirName));
         }
     }
 

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -115,6 +115,7 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     protected String hybrisVersion;
     protected boolean createBackwardCyclicDependenciesForAddOns;
     protected boolean followSymlink;
+    protected boolean excludeTestSources;
     protected boolean scanThroughExternalModule;
     @NotNull
     private ConfigHybrisModuleDescriptor configHybrisModuleDescriptor;
@@ -896,6 +897,16 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     @Override
     public boolean isFollowSymlink() {
         return followSymlink;
+    }
+
+    @Override
+    public void setExcludeTestSources(final boolean excludeTestSources) {
+        this.excludeTestSources = excludeTestSources;
+    }
+
+    @Override
+    public boolean isExcludeTestSources() {
+        return excludeTestSources;
     }
 
     @Override

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
@@ -122,6 +122,10 @@ public interface HybrisProjectDescriptor {
 
     boolean isFollowSymlink();
 
+    void setExcludeTestSources(boolean excludeTestSources);
+
+    boolean isExcludeTestSources();
+
     void setScanThroughExternalModule(boolean scanThroughExternalModule);
 
     boolean isScanThroughExternalModule();

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -412,6 +412,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
                                .filter(e -> e instanceof OotbHybrisModuleDescriptor || e instanceof CustomHybrisModuleDescriptor)
                                .forEach(e -> completeSetOfHybrisModules.add(e.getName()));
         hybrisProjectSettings.setCompleteSetOfAvailableExtensionsInHybris(completeSetOfHybrisModules);
+        hybrisProjectSettings.setExcludeTestSources(hybrisProjectDescriptor.isExcludeTestSources());
     }
 
     private Set<String> createModulesOnBlackList() {

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.form
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.intellij.idea.plugin.hybris.project.wizard.HybrisWorkspaceRootStep">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="16" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="17" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="773" height="744"/>
@@ -351,7 +351,7 @@
       </grid>
       <vspacer id="286f1">
         <constraints>
-          <grid row="15" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="16" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="5e798" class="javax.swing.JLabel" binding="dbDriversDirOverrideLabel">
@@ -400,6 +400,22 @@
         <properties>
           <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.scannExternalModules"/>
           <toolTipText value=""/>
+        </properties>
+      </component>
+      <component id="69f88" class="javax.swing.JCheckBox" binding="excludeTestSourcesCheckBox">
+        <constraints>
+          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <component id="c4fda" class="javax.swing.JLabel" binding="excludeTestSourcesLabel">
+        <constraints>
+          <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="i18n/HybrisBundle" key="hybris.import.wizard.exclude.test.sources.label"/>
         </properties>
       </component>
     </children>

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.java
@@ -98,6 +98,8 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
     private JCheckBox followSimplinkCheckbox;
     private JLabel scanThroughExternalModuleLabel;
     private JCheckBox scanThroughExternalModuleCheckbox;
+    private JCheckBox excludeTestSourcesCheckBox;
+    private JLabel excludeTestSourcesLabel;
     private String hybrisVersion;
     public HybrisWorkspaceRootStep(final WizardContext context) {
         super(context);
@@ -262,6 +264,10 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
             this.followSimplinkCheckbox.isSelected()
         );
 
+        this.getContext().getHybrisProjectDescriptor().setExcludeTestSources(
+            this.excludeTestSourcesCheckBox.isSelected()
+        );
+
         this.getContext().getHybrisProjectDescriptor().setScanThroughExternalModule(
             this.scanThroughExternalModuleCheckbox.isSelected()
         );
@@ -345,6 +351,9 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
         hybrisProjectDescriptor.setScanThroughExternalModule(
             appSettings.isScanThroughExternalModule()
         );
+        hybrisProjectDescriptor.setExcludeTestSources(
+            appSettings.isExcludeTestSources()
+        );
         this.importOotbModulesInReadOnlyModeCheckBox.setSelected(
             hybrisProjectDescriptor.isImportOotbModulesInReadOnlyMode()
         );
@@ -353,6 +362,9 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
         );
         this.followSimplinkCheckbox.setSelected(
             hybrisProjectDescriptor.isFollowSymlink()
+        );
+        this.excludeTestSourcesCheckBox.setSelected(
+            hybrisProjectDescriptor.isExcludeTestSources()
         );
 
         if (StringUtils.isBlank(this.hybrisDistributionDirectoryFilesInChooser.getText())) {
@@ -578,6 +590,7 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
         hybrisProjectDescriptor.setCreateBackwardCyclicDependenciesForAddOns(settings.isCreateBackwardCyclicDependenciesForAddOns());
         hybrisProjectDescriptor.setImportOotbModulesInReadOnlyMode(settings.getImportOotbModulesInReadOnlyMode());
         hybrisProjectDescriptor.setFollowSymlink(settings.isFollowSymlink());
+        hybrisProjectDescriptor.setExcludeTestSources(settings.isExcludeTestSources());
         hybrisProjectDescriptor.setScanThroughExternalModule(settings.isScanThroughExternalModule());
 
         this.getContext().setRootProjectDirectory(new File(this.getBuilder().getFileToImport()));
@@ -615,6 +628,10 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
             return null;
         }
         return file;
+    }
+
+    private void createUIComponents() {
+        // TODO: place custom component creation code here
     }
 
     private class MySourceCodeChooserActionListener

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
@@ -123,6 +123,9 @@ public class HybrisApplicationSettings {
     @PropertyName("scanThroughExternalModule")
     private boolean scanThroughExternalModule = false;
 
+    @PropertyName("excludeTestSources")
+    private boolean excludeTestSources = false;
+
     public HybrisApplicationSettings() {
     }
 
@@ -302,6 +305,14 @@ public class HybrisApplicationSettings {
         this.scanThroughExternalModule = scanThroughExternalModule;
     }
 
+    public boolean isExcludeTestSources() {
+        return excludeTestSources;
+    }
+
+    public void setExcludeTestSources(final boolean excludeTestSources) {
+        this.excludeTestSources = excludeTestSources;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
@@ -327,6 +338,7 @@ public class HybrisApplicationSettings {
             .append(sourceCodeDirectory)
             .append(sourceZipUsed)
             .append(developmentMode)
+            .append(excludeTestSources)
             .toHashCode();
     }
 
@@ -365,6 +377,7 @@ public class HybrisApplicationSettings {
             .append(sourceCodeDirectory, other.sourceCodeDirectory)
             .append(sourceZipUsed, other.sourceZipUsed)
             .append(developmentMode, other.developmentMode)
+            .append(excludeTestSources, other.excludeTestSources)
             .isEquals();
     }
 
@@ -393,6 +406,7 @@ public class HybrisApplicationSettings {
         sb.append(", sourceCodeDirectory='").append(sourceCodeDirectory).append('\'');
         sb.append(", sourceZipUsed='").append(sourceZipUsed).append('\'');
         sb.append(", developmentMode='").append(developmentMode).append('\'');
+        sb.append(", excludeTestSources='").append(excludeTestSources).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.form
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.form
@@ -111,7 +111,7 @@
           <grid row="9" column="0" row-span="1" col-span="5" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
-      <grid id="410c1" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="410c1" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="12" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
@@ -162,6 +162,15 @@
             <properties>
               <selected value="false"/>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.scannExternalModules"/>
+            </properties>
+          </component>
+          <component id="7c462" class="javax.swing.JCheckBox" binding="excludeTestSources">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="false"/>
+              <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.excludeTestSources"/>
             </properties>
           </component>
         </children>

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.java
@@ -59,6 +59,7 @@ public class HybrisApplicationSettingsForm {
     private JCheckBox followSymlink;
     private JPanel typeSystemDiagramStopWords;
     private JCheckBox scanThroughExternalModule;
+    private JCheckBox excludeTestSources;
 
     private MyListPanel junkListPanel;
     private MyListPanel tsdListPanel;
@@ -79,6 +80,7 @@ public class HybrisApplicationSettingsForm {
         defaultPlatformInReadOnly.setSelected(data.isDefaultPlatformInReadOnly());
         followSymlink.setSelected(data.isFollowSymlink());
         scanThroughExternalModule.setSelected(data.isScanThroughExternalModule());
+        excludeTestSources.setSelected(data.isExcludeTestSources());
     }
 
     public void getData(final HybrisApplicationSettings data) {
@@ -97,7 +99,7 @@ public class HybrisApplicationSettingsForm {
         data.setDefaultPlatformInReadOnly(defaultPlatformInReadOnly.isSelected());
         data.setFollowSymlink(followSymlink.isSelected());
         data.setScanThroughExternalModule(scanThroughExternalModule.isSelected());
-
+        data.setExcludeTestSources(excludeTestSources.isSelected());
     }
 
     public boolean isModified(final HybrisApplicationSettings data) {
@@ -144,6 +146,9 @@ public class HybrisApplicationSettingsForm {
             return true;
         }
         if (followSymlink.isSelected() != data.isFollowSymlink()) {
+            return true;
+        }
+        if (excludeTestSources.isSelected() != data.isExcludeTestSources()) {
             return true;
         }
         return false;

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettings.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettings.java
@@ -53,6 +53,7 @@ public class HybrisProjectSettings {
     protected boolean followSymlink;
     protected boolean scanThroughExternalModule;
     protected boolean createBackwardCyclicDependenciesForAddOns = false;
+    protected boolean excludeTestSources;
     protected Set<String> completeSetOfAvailableExtensionsInHybris = newHashSet();
     protected Set<String> unusedExtensions = newHashSet();
     protected Set<String> modulesOnBlackList = newHashSet();
@@ -209,6 +210,14 @@ public class HybrisProjectSettings {
         this.scanThroughExternalModule = scanThroughExternalModule;
     }
 
+    public boolean isExcludeTestSources() {
+        return excludeTestSources;
+    }
+
+    public void setExcludeTestSources(final boolean excludeTestSources) {
+        this.excludeTestSources = excludeTestSources;
+    }
+
     public Set<String> getCompleteSetOfAvailableExtensionsInHybris() {
         return completeSetOfAvailableExtensionsInHybris;
     }
@@ -262,6 +271,7 @@ public class HybrisProjectSettings {
             .append(hacPassword)
             .append(importOotbModulesInReadOnlyMode)
             .append(followSymlink)
+            .append(excludeTestSources)
             .append(scanThroughExternalModule)
             .append(completeSetOfAvailableExtensionsInHybris)
             .append(createBackwardCyclicDependenciesForAddOns)
@@ -300,6 +310,7 @@ public class HybrisProjectSettings {
             .append(hacPassword, other.hacPassword)
             .append(importOotbModulesInReadOnlyMode, other.importOotbModulesInReadOnlyMode)
             .append(followSymlink, other.followSymlink)
+            .append(excludeTestSources, other.excludeTestSources)
             .append(scanThroughExternalModule, other.scanThroughExternalModule)
             .append(completeSetOfAvailableExtensionsInHybris, other.completeSetOfAvailableExtensionsInHybris)
             .append(createBackwardCyclicDependenciesForAddOns, other.createBackwardCyclicDependenciesForAddOns)
@@ -328,6 +339,7 @@ public class HybrisProjectSettings {
         sb.append("hacPassword=").append(hacPassword);
         sb.append("importOotbModulesInReadOnlyMode=").append(importOotbModulesInReadOnlyMode);
         sb.append("followSymlink=").append(followSymlink);
+        sb.append("excludeTestSources=").append(excludeTestSources);
         sb.append("scanThroughExternalModule=").append(scanThroughExternalModule);
         sb.append("completeSetOfAvailableExtensionsInHybris=").append(completeSetOfAvailableExtensionsInHybris);
         sb.append("createBackwardCyclicDependenciesForAddOns=").append(createBackwardCyclicDependenciesForAddOns);


### PR DESCRIPTION
provide a checkbox during project import to exclude all testsrc folders from Hybris OOTB modules

Signed-off-by: Fabian Necci fabian.necci@gmail.com

