### PR TITLE
IIP-463 Eclipse projects should be placed in module groups

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/project/configurators/EclipseConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/EclipseConfigurator.java
@@ -20,12 +20,12 @@ package com.intellij.idea.plugin.hybris.project.configurators;
 
 import com.intellij.idea.plugin.hybris.project.descriptors.EclipseModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisProjectDescriptor;
-import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Martin Zdarsky-Jones (martin.zdarsky@hybris.com) on 15/11/16.
@@ -36,6 +36,6 @@ public interface EclipseConfigurator {
         @NotNull final HybrisProjectDescriptor hybrisProjectDescriptor,
         @NotNull final Project project,
         @NotNull final List<EclipseModuleDescriptor> eclipseModules,
-        @Nullable final String[] eclipseRootGroup
+        @Nullable final Map<String,String[]> eclipseGroupMapping
     );
 }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultEclipseConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultEclipseConfigurator.java
@@ -36,6 +36,7 @@ import org.jetbrains.idea.eclipse.importWizard.EclipseImportBuilder;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -48,7 +49,7 @@ public class DefaultEclipseConfigurator implements EclipseConfigurator {
         @NotNull final HybrisProjectDescriptor hybrisProjectDescriptor,
         @NotNull final Project project,
         @NotNull final List<EclipseModuleDescriptor> eclipseModules,
-        @Nullable final String[] eclipseGroup
+        @Nullable final Map<String,String[]> eclipseGroupMapping
     ) {
         if (eclipseModules.isEmpty()) {
             return;
@@ -66,7 +67,7 @@ public class DefaultEclipseConfigurator implements EclipseConfigurator {
         eclipseImportBuilder.setList(projectList);
         ApplicationManager.getApplication().invokeAndWait(() -> {
             final List<Module> newRootModules = eclipseImportBuilder.commit(project);
-            moveEclipseModulesToGroup(project, newRootModules, eclipseGroup);
+            moveEclipseModulesToGroup(project, newRootModules, eclipseGroupMapping);
         });
 
     }
@@ -74,13 +75,13 @@ public class DefaultEclipseConfigurator implements EclipseConfigurator {
     private void moveEclipseModulesToGroup(
         @NotNull final Project project,
         @NotNull final List<Module> eclipseModules,
-        @Nullable final String[] eclipseGroup
+        @Nullable final Map<String,String[]> eclipseGroupMapping
     ) {
         final ModifiableModuleModel modifiableModuleModel = ModuleManager.getInstance(project).getModifiableModel();
 
         for (Module module : eclipseModules) {
             module.setOption(HybrisConstants.DESCRIPTOR_TYPE, HybrisModuleDescriptorType.ECLIPSE.name());
-            modifiableModuleModel.setModuleGroupPath(module, eclipseGroup);
+            modifiableModuleModel.setModuleGroupPath(module, eclipseGroupMapping.get(module.getName()));
         }
         AccessToken token = null;
         try {

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -95,6 +95,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -281,9 +282,9 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
                     .map(e -> (EclipseModuleDescriptor) e)
                     .collect(Collectors.toList());
                 if (!eclipseModules.isEmpty()) {
-                    final String[] eclipseRootGroup = configuratorFactory.getGroupModuleConfigurator().getGroupName(
-                        eclipseModules.get(0));
-                    eclipseConfigurator.configure(hybrisProjectDescriptor, project, eclipseModules, eclipseRootGroup);
+                    final Map<String, String[]> eclipseGroupMapping = eclipseModules.stream().collect(Collectors.
+                         toMap(EclipseModuleDescriptor::getName, groupModuleConfigurator::getGroupName));
+                    eclipseConfigurator.configure(hybrisProjectDescriptor, project, eclipseModules, eclipseGroupMapping);
                 }
             } catch (Exception e) {
                 LOG.error("Can not import Eclipse modules due to an error.", e);


### PR DESCRIPTION
IIP-463 Eclipse projects should be placed in module groups according to config file  hybris4intellij.properties

Previously all the eclipse projects were placed into the module group for the first module found. Changed to lookup the module group for each eclipse project and map each to the speccified group.

Signed-off-by: Nicko Cadell ncadell@salmon.com