### PR TITLE
IIP-468 Fix compilation problems when OOTB extensions are imported in read-only mode

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/ReadOnlyContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/ReadOnlyContentRootConfigurator.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.vfs.VfsUtil;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.jps.model.java.JavaResourceRootType;
 
 import java.io.File;
 import java.util.List;
@@ -31,7 +32,9 @@ import static com.intellij.idea.plugin.hybris.common.HybrisConstants.ADDON_SRC_D
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.BACK_OFFICE_MODULE_DIRECTORY;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.CLASSES_DIRECTORY;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.COMMON_WEB_SRC_DIRECTORY;
+import static com.intellij.idea.plugin.hybris.common.HybrisConstants.RESOURCES_DIRECTORY;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.TEST_CLASSES_DIRECTORY;
+import static com.intellij.idea.plugin.hybris.common.HybrisConstants.WEB_MODULE_DIRECTORY;
 
 /**
  * Created by Martin Zdarsky-Jones <zdary@zdary.cz> on 12/4/17.
@@ -43,9 +46,8 @@ public class ReadOnlyContentRootConfigurator extends RegularContentRootConfigura
         @NotNull final ContentEntry contentEntry,
         @NotNull final List<File> dirsToIgnore
     ) {
-        Validate.notNull(moduleDescriptor);
-        Validate.notNull(contentEntry);
-
+        final File resourcesDirectory = new File(moduleDescriptor.getRootDirectory(), RESOURCES_DIRECTORY);
+        addSourceFolderIfNotIgnored(contentEntry, resourcesDirectory, JavaResourceRootType.RESOURCE, dirsToIgnore);
         excludeCommonNeedlessDirs(contentEntry, moduleDescriptor);
     }
 
@@ -69,6 +71,12 @@ public class ReadOnlyContentRootConfigurator extends RegularContentRootConfigura
         contentEntry.addExcludeFolder(
             VfsUtil.pathToUrl(additionalClassesDirectory.getAbsolutePath())
         );
+
+        final File additionalResourcesDirectory = new File(additionalModuleDirectory, RESOURCES_DIRECTORY);
+        contentEntry.addSourceFolder(
+            VfsUtil.pathToUrl(additionalResourcesDirectory.getAbsolutePath()),
+            JavaResourceRootType.RESOURCE
+        );
     }
 
     protected void configureBackOfficeRoots(
@@ -87,15 +95,21 @@ public class ReadOnlyContentRootConfigurator extends RegularContentRootConfigura
         contentEntry.addExcludeFolder(
             VfsUtil.pathToUrl(hmcClassesDirectory.getAbsolutePath())
         );
+
+        final File hmcResourcesDirectory = new File(backOfficeModuleDirectory, RESOURCES_DIRECTORY);
+        contentEntry.addSourceFolder(
+            VfsUtil.pathToUrl(hmcResourcesDirectory.getAbsolutePath()),
+            JavaResourceRootType.RESOURCE
+        );
     }
 
-    protected void configureWebModuleRoots(
+    @Override
+    protected void configureRegularWebRoots(
         @NotNull final HybrisModuleDescriptor moduleDescriptor,
-        final @NotNull ContentEntry contentEntry,
-        @NotNull final File webModuleDirectory,
+        @NotNull final ContentEntry contentEntry,
         @NotNull final List<File> dirsToIgnore
     ) {
-        Validate.notNull(moduleDescriptor);
+        final File webModuleDirectory = new File(moduleDescriptor.getRootDirectory(), WEB_MODULE_DIRECTORY);
 
         final File webAddonSrcDirectory = new File(webModuleDirectory, ADDON_SRC_DIRECTORY);
         contentEntry.addExcludeFolder(

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -114,11 +114,19 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             contentEntry,
             moduleDescriptor.getRootDirectory()
         );
-        this.configureWebRoots(moduleDescriptor, contentEntry, moduleDescriptor.getRootDirectory(), dirsToIgnore);
+        configureRegularWebRoots(moduleDescriptor, contentEntry, dirsToIgnore);
         this.configureCommonWebRoots(moduleDescriptor, contentEntry, dirsToIgnore);
         this.configureAcceleratorAddonRoots(moduleDescriptor, contentEntry, dirsToIgnore);
         this.configureBackOfficeRoots(moduleDescriptor, contentEntry, dirsToIgnore);
         this.configurePlatformRoots(moduleDescriptor, contentEntry);
+    }
+
+    protected void configureRegularWebRoots(
+        @NotNull final HybrisModuleDescriptor moduleDescriptor,
+        @NotNull final ContentEntry contentEntry,
+        @NotNull final List<File> dirsToIgnore
+    ) {
+        configureWebRoots(moduleDescriptor, contentEntry, moduleDescriptor.getRootDirectory(), dirsToIgnore);
     }
 
     protected void configureCommonRoots(
@@ -144,7 +152,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             dirsToIgnore
         );
 
-        if(moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
+        if (moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor()
+                                                                                         .isExcludeTestSources()) {
             addTestSourceRoots(contentEntry, moduleDescriptor.getRootDirectory(), dirsToIgnore);
         } else {
             excludeTestSourceRoots(contentEntry, moduleDescriptor.getRootDirectory());
@@ -223,10 +232,6 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
         @NotNull final File parentDirectory,
         @NotNull final List<File> dirsToIgnore
     ) {
-        Validate.notNull(moduleDescriptor);
-        Validate.notNull(contentEntry);
-        Validate.notNull(parentDirectory);
-
         final File webModuleDirectory = new File(parentDirectory, WEB_MODULE_DIRECTORY);
         this.configureWebModuleRoots(moduleDescriptor, contentEntry, webModuleDirectory, dirsToIgnore);
     }
@@ -279,7 +284,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             JavaSourceRootType.SOURCE
         );
 
-        if(moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
+        if (moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor()
+                                                                                         .isExcludeTestSources()) {
             addTestSourceRoots(contentEntry, backOfficeModuleDirectory, dirsToIgnore);
         } else {
             excludeTestSourceRoots(contentEntry, backOfficeModuleDirectory);
@@ -346,7 +352,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             JpsJavaExtensionService.getInstance().createSourceRootProperties("", true)
         );
 
-        if(moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
+        if (moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor()
+                                                                                         .isExcludeTestSources()) {
             addTestSourceRoots(contentEntry, webModuleDirectory, dirsToIgnore);
         } else {
             excludeTestSourceRoots(contentEntry, webModuleDirectory);
@@ -362,7 +369,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     private static void addTestSourceRoots(
         @NotNull final ContentEntry contentEntry,
         @NotNull final File dir,
-        @NotNull final List<File> dirsToIgnore) {
+        @NotNull final List<File> dirsToIgnore
+    ) {
 
         for (String testSrcDirName : TEST_SRC_DIR_NAMES) {
             addSourceFolderIfNotIgnored(
@@ -376,14 +384,15 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
 
     private static void excludeTestSourceRoots(
         @NotNull final ContentEntry contentEntry,
-        @NotNull final File dir) {
+        @NotNull final File dir
+    ) {
 
         for (String testSrcDirName : TEST_SRC_DIR_NAMES) {
             excludeDirectory(contentEntry, new File(dir, testSrcDirName));
         }
     }
 
-    private static <P extends JpsElement> void addSourceFolderIfNotIgnored(
+    protected static <P extends JpsElement> void addSourceFolderIfNotIgnored(
         @NotNull final ContentEntry contentEntry,
         @NotNull final File testSrcDir,
         @NotNull final JpsModuleSourceRootType<P> rootType,


### PR DESCRIPTION
- Don't exclude src folders located in "acceleratoraddon" and "commonweb" dirs, because AddOnCopyingBuilder works incorrectly then
- Mark resource all directories to make ModelSourceGeneratingBuilder working correctly

Signed-off-by: Evgenii Kudelevskii ekudel@gmail.com