### PR TITLE
IIPS-189 Exclude "httpcomponents" libraries from "solr" dependency to avoid the conflict with newer versions of these libraries bundled with IntelliJ Platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
     compile("org.apache.solr:solr-solrj:7.5.0") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+        exclude group: 'org.apache.httpcomponents', module: 'httpcore'
+        exclude group: 'org.apache.httpcomponents', module: 'httpmime'
     }
 
     compile "com.github.ben-manes.caffeine:caffeine:2.6.2"


### PR DESCRIPTION
Signed-off-by: Evgenii Kudelevskii ekudel@gmail.com